### PR TITLE
fix "push sp"

### DIFF
--- a/i8086.cxx
+++ b/i8086.cxx
@@ -1017,7 +1017,14 @@ not_inlined bool i8086::op_ff()
     {
         AddCycles( 22 );
         uint16_t * pval = get_rm_ptr16();
-        push( *pval );
+
+        auto val = *pval;
+        // SP special case
+        if (_mod == 3 && _rm == 4) {
+            val -= 2;
+        }
+        push( val );
+
         _bc++;
     }
     else

--- a/i8086.cxx
+++ b/i8086.cxx
@@ -1019,7 +1019,7 @@ not_inlined bool i8086::op_ff()
         uint16_t * pval = get_rm_ptr16();
 
         auto val = *pval;
-        // SP special case
+        // SP special case (for `push <reg>` behavior, might be undocumented)
         if (_mod == 3 && _rm == 4) {
             val -= 2;
         }


### PR DESCRIPTION
"PUSH SP" when issued via the `0xFF` instruction is incorrect, in the same way as my fix for `0x54` from yesterday.

However, I'm not in love with this fix, it's not "clean" so maybe you have a better idea, but besides that, this completely fixes the issue.